### PR TITLE
fix bug wrong player checkers draggable

### DIFF
--- a/src/components/BoardPoint/BoardPoint.tsx
+++ b/src/components/BoardPoint/BoardPoint.tsx
@@ -25,7 +25,7 @@ const BoardPoint: FC<PointProps> = ({
   children
 }) => {
   const [{ isOver, canDrop }, dropRef] = useDrop(() => ({
-    accept: ItemTypes.CHECKER1 || ItemTypes.CHECKER2,
+    accept: ItemTypes.CHECKER1 && ItemTypes.CHECKER2,
     canDrop: (item) =>
       validMoves(pointIndex, item as { fromPoint: number; checkerColor: any }),
     drop: (item) =>

--- a/src/components/GameBoard/GameBoard.tsx
+++ b/src/components/GameBoard/GameBoard.tsx
@@ -105,6 +105,12 @@ const GameBoard: FC = () => {
     console.log(valid)
 
     // TODO:
+    console.log(
+      !!valid
+        ?.map((move) => move.action !== 'closed' && move.point)
+        .includes(dropPoint)
+    )
+
     return !!valid
       ?.map((move) => move.action !== 'closed' && move.point)
       .includes(dropPoint)

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -35,7 +35,7 @@ export const INITIAL_TABLE_STATE: TableState = {
     bearOff1: [],
     bearOff2: []
   },
-  activePlayer: 2,
+  activePlayer: 1,
   // TODO: activePlayer: null,
   diceState: {
     diceRoll: [0, 0, 0, 0],


### PR DESCRIPTION
Fixes #1. The accept in `useDrop > BoardPoint.tsx` was using an || operator. Now fixed with &&.